### PR TITLE
Add Missing NoiseType definition for Unity

### DIFF
--- a/NoiseDotNet/Noise.cs
+++ b/NoiseDotNet/Noise.cs
@@ -916,6 +916,14 @@ namespace NoiseDotNet
 
 #if UNITY
 
+    public enum NoiseType
+    {
+        GradientNoise2D,
+        GradientNoise3D,
+        CellularNoise2D,
+        CellularNoise3D
+    }
+    
     /// <summary>
     /// Burst Job for evaluating noise functions from the <see cref="Noise"/> class.
     /// Used by the functions in the <see cref="Noise"/> class internally, however if you want to run the job asynchronously you can use this struct.


### PR DESCRIPTION
When adding `Noise.cs` to Unity it has compile errors due to NoiseType not behind defined.

I've added one defined within a `#if UNITY`

Feel free to close if this is a user error on my end!